### PR TITLE
fix timeout on error

### DIFF
--- a/src/api/slack/slack.commands.ts
+++ b/src/api/slack/slack.commands.ts
@@ -24,9 +24,11 @@ const handleCodeReview = async (bot: BotWorker, message: BotkitMessage) => {
 
         switch (origin) {
             case EReviewRequestOrigin.GITLAB:
-                return helper.saveGitlabMR(bot, message);
+                await helper.saveGitlabMR(bot, message);
+                break;
             case EReviewRequestOrigin.AZURE:
-                return helper.saveAzurePR(bot, message);
+                await helper.saveAzurePR(bot, message);
+                break;
             default:
                 throw new Message('Não posso aceitar links desse git :disappointed:');
         }
@@ -34,12 +36,12 @@ const handleCodeReview = async (bot: BotWorker, message: BotkitMessage) => {
         if (err instanceof Message) {
             logger.info(err);
 
-            return slack.sendEphemeral(message, err.message);
+            await slack.sendEphemeral(message, err.message);
+        } else {
+            logger.error(err.stack || err);
+
+            throw err;
         }
-
-        logger.error(err.stack || err);
-
-        throw err;
     }
 };
 


### PR DESCRIPTION
bug: ao enviar um link que já está na base ocorre erro de timeout no slack

situação: utilizando `return` no `switch` a stack de erro é retornada para a função acima, ignorando o `try-catch` de onde o método é chamado

correção: foi realizada a troca do `return` pelo `await`, assim a `promise` é resolvida dentro do `try` e segue seu fluxo normal dentro do `catch` em caso de erro