### PR TITLE
Adicionando suporte as versões 13+ do Gitlab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "code-review-bot",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-review-bot",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Bot para controle de fila de code review",
   "main": "dist/app.js",
   "scripts": {

--- a/src/api/gitlab/gitlab.helper.ts
+++ b/src/api/gitlab/gitlab.helper.ts
@@ -3,7 +3,9 @@ import { GitlabMergeRequestUrlInfo } from './gitlab.interfaces';
 const regex = /(.*)\/merge_requests\/(.\d*)/;
 
 const getUrlInfo = (url: string): GitlabMergeRequestUrlInfo => {
-    const [,,, ...path] = url.split('/');
+    const oldUrlPattern = url.replace('/-/', '/');
+
+    const [,,, ...path] = oldUrlPattern.split('/');
 
     const groups = regex.exec(path.join('/'));
 


### PR DESCRIPTION
A partir da versão 13 do gitlab ele foi adicionado um /-/ na url, quebrando a lógica que busca os merge requests.

Se chamarmos a url sem a /-/ o gitlab automaticamente faz o redirect, então apenas removi essa parte da string, mantendo assim o suporte para as versões anteriores também.
 